### PR TITLE
Update DIS.html

### DIFF
--- a/DIS.html
+++ b/DIS.html
@@ -90,7 +90,7 @@
         <li>Wait for it to copy</li>
         <li>Exist System Settings</li>
         <li>Start your Game.<br/>
-            You should be greeted by a white screen complaining that it could not load a file. <strong>this is the
+            You should be greeted by a white screen complaining that it could not load a file (or solid light-green screens, top and bottom, with no text at all). <strong>This is the
                 intended result.</strong><br/>
             <strong>NOTE:</strong> if you used SUDOKU, you may need to tap the touchscreen so the Game loads the
             modified save file


### PR DESCRIPTION
This reflects the new changes in the Jenkin's site. There are new 16KB saves files for sudoku that use @fincs minitwlpayload that do not inform of any missing boot.nds files. This is done, in part, to make the payload as small as possible. With 16KB public.savs, dsiware injection with sukoku compatibility is increased by a factor of five. 83% of US dsiware, and 86% of EU dsiware titles are now supported.